### PR TITLE
Add disk monitoring

### DIFF
--- a/files/check_slx_disks.sh
+++ b/files/check_slx_disks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# 2025 by mira-miracoli (GitHub)
+# Checks if SLX detected the root disk, set it up correctly and mounted the scratch storage
+
+dmsetup="/dev/mapper/scratch * type=1
+/dev/mapper/tank * type=1
+/dev/mapper/root / type=1"
+disk_setup=0
+if [ "$(cat /run/openslx/dmsetup.state | grep -v "#" | cut -d, -f 1)" = "$dmsetup" ]; then
+    disk_setup=1
+fi
+
+# Check for OPENSLX_SYS partition label
+openslx_label=0
+if blkid | grep -qs "OPENSLX_SYS"; then
+    openslx_label=1
+fi
+
+# Check that scratch is mounted
+scratch=0
+SCRATCH_MOUNT=/scratch
+if [ "$disk_setup" ] && grep -qs "$SCRATCH_MOUNT" /proc/mounts; then
+    scratch=1
+fi
+
+echo "pxe.disk_mode,host=$(cat /etc/hostname) openslx_label=$openslx_label,scratch_mounted=$scratch,disksetup_ok=$disk_setup"

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -26,5 +26,5 @@ check_slx_disks_telegraf:
       - commands = ["/usr/bin/check_slx_disks"]
       - timeout = "2m"
       - data_format = "influx"
-      - interval = "5m"
+      - interval = "1m"
 telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(check_slx_disks) }}"

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -16,3 +16,15 @@ rank: GalaxyGroup
 base_cgroup: htcondor
 memory_limit_policy: hard
 reserved_memory: 2048
+
+
+## Telegraf
+check_slx_disks_telegraf:
+  check_slx_disks_telegraf:
+    plugin: exec
+    config:
+      - commands = ["/usr/bin/check_slx_disks"]
+      - timeout = "2m"
+      - data_format = "influx"
+      - interval = "5m"
+telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(check_slx_disks) }}"

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -19,7 +19,8 @@ reserved_memory: 2048
 
 
 ## Telegraf
-check_slx_disks_telegraf:
+telegraf_agent_config_path: /etc/telegraf
+telegraf_plugins_extra:
   check_slx_disks_telegraf:
     plugin: exec
     config:
@@ -27,4 +28,3 @@ check_slx_disks_telegraf:
       - timeout = "2m"
       - data_format = "influx"
       - interval = "1m"
-telegraf_plugins_extra: "{{ telegraf_plugins_extra | combine(check_slx_disks) }}"

--- a/templates/telegraf-extra-plugin.conf.j2
+++ b/templates/telegraf-extra-plugin.conf.j2
@@ -1,0 +1,71 @@
+### MANAGED BY ANSIBLE ###
+
+[[inputs.{{ item.value.plugin | default(item.key) }}]]
+{% if item.value.interval is defined %}
+    interval = "{{ item.value.interval }}s"
+{% endif %}
+{% if item.value.config is defined and item.value.config is iterable %}
+{% for items in item.value.config %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.value.tags is defined and item.value.tags is iterable %}
+[inputs.{{ item.value.plugin | default(item.key) }}.tags]
+{% for items in item.value.tags %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.value.tagpass is defined and item.value.tagpass is iterable %}
+[inputs.{{ item.value.plugin | default(item.key) }}.tagpass]
+{% for items in item.value.tagpass %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.value.tagdrop is defined and item.value.tagdrop is iterable %}
+[inputs.{{ item.value.plugin | default(item.key) }}.tagdrop]
+{% for items in item.value.tagdrop %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% if item.value.filter is defined %}
+{% if item.value.filter.name is defined %}
+[inputs.{{ item.value.plugin | default(item.key) }}.{{ item.value.filter.name | default("grok") }}]
+{% if item.value.filter.config is defined and item.value.filter.config is iterable %}
+{% for items in item.value.filter.config %}
+    {{ items }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% if item.value.objects is defined and item.value.objects is iterable %}
+{% for object in item.value.objects %}
+[[inputs.{{ item.value.plugin | default(item.key) }}.object]]
+  ObjectName = {{ object.name | to_json }}
+  Instances = {{ object.instances | default(["*"]) | to_json }}
+  Counters = {{ object.counters | default(["*"]) | to_json }}
+  Measurement = {{ object.measurement | default("win_perf_counters") | to_json }}
+  IncludeTotal = {{ object.total | default(false) | string | lower }}
+{% endfor %}
+{% endif %}
+{% if item.value.queries is defined and item.value.queries is iterable %}
+{% for query in item.value.queries %}
+[[inputs.{{ item.value.plugin | default(item.key) }}.query]]
+{% for item in item.value.queries[query] %}
+    {{ item }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% if item.value.sub_inputs is defined and item.value.sub_inputs is iterable %}
+{% for sub_input_key, sub_input_list in item.value.sub_inputs.items() %}
+{% for block in sub_input_list %}
+[[inputs.{{ item.value.plugin | default(item.key) }}.{{ sub_input_key }}]]
+{% for param_key, param_value in block.items() %}
+{% if param_value is sequence and param_value is not string %}
+    {{ param_key }} = {{ param_value | to_json }}
+{% else %}
+    {{ param_key }} = "{{ param_value }}"
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -7,14 +7,14 @@
   vars:
     internal: true
   handlers:
-    - name: Reload Telegraf
+    - name: Restart Telegraf
       ansible.builtin.service:
         name: telegraf
-        state: reloaded
-    - name: Reload HTCondor
+        state: restarted
+    - name: Restart HTCondor
       ansible.builtin.service:
         name: condor
-        state: reloaded
+        state: restarted
   pre_tasks:
     - name: Ensure the HTCondor configuration directory exists.
       become: true
@@ -32,7 +32,7 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Reload HTCondor
+      notify: Restart HTCondor
     - name: Template HTCondor host specific configuration.
       ansible.builtin.template:
         src: 99-cloud-init.conf.j2
@@ -40,23 +40,23 @@
         owner: root
         group: root
         mode: "0644"
-      notify: Reload HTCondor
+      notify: Restart HTCondor
   tasks:
     - name: Update Telegraf hostname
       ansible.builtin.lineinfile:
-        path: /etc/telegraf/telegraf.conf
+        path: "{{ telegraf_agent_config_path }}/telegraf.conf"
         search_string: '    hostname = "localhost.localdomain"'
         line: '    hostname = "{{ ansible_fqdn }}"'
-      notify: Reload Telegraf
+      notify: Restart Telegraf
     - name: Copy Telegraf credentials
       ansible.builtin.template:
         src: output.conf.j2
-        dest: /etc/telegraf/telegraf.d/output.conf
+        dest: "{{ telegraf_agent_config_path }}/telegraf.d/output.conf"
         mode: "0640"
         owner: telegraf
         group: telegraf
       no_log: true
-      notify: Reload Telegraf
+      notify: Restart Telegraf
     - name: Deploy SLX disk monitor script
       ansible.builtin.copy:
         src: check_slx_disks.sh
@@ -64,7 +64,24 @@
         owner: root
         group: root
         mode: 0755
-      notify: Reload Telegraf
+      notify: Restart Telegraf
+    - name: "Copy telegraf extra plugins"
+      template:
+        src: "telegraf-extra-plugin.conf.j2"
+        dest: "{{ telegraf_agent_config_path }}/telegraf.d/{{ item.key }}.conf"
+        owner: telegraf
+        group: telegraf
+        mode: 0640
+      with_dict: "{{ telegraf_plugins_extra }}"
+      loop_control:
+        label: "{{ item.key }}"
+      when:
+        - telegraf_plugins_extra is defined
+        - telegraf_plugins_extra is iterable
+        - item.value.state|default('present') != 'absent'
+      become: true
+      notify:
+        - Restart Telegraf
 
   roles:
     - usegalaxy_eu.firewall

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -58,7 +58,7 @@
       no_log: true
       notify: Reload Telegraf
     - name: Deploy SLX disk monitor script
-      ansible.builtin.template:
+      ansible.builtin.copy:
         src: check_slx_disks.sh
         dest: /usr/bin/check_slx_disks
         owner: root

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -57,6 +57,14 @@
         group: telegraf
       no_log: true
       notify: Reload Telegraf
+    - name: Deploy SLX disk monitor script
+      ansible.builtin.template:
+        src: check_slx_disks.sh
+        dest: /usr/bin/check_slx_disks
+        owner: root
+        group: root
+        mode: 0755
+      notify: Reload Telegraf
 
   roles:
     - usegalaxy_eu.firewall


### PR DESCRIPTION
This script checks if
- the host has a disk with `PARTLABEL="OPENSLX_SYS"`
- uses the disks as write layer for dnbd and not ramdisk
- has the `scratch` storage mounted
This is consumed by telegraf and then displayed in [this dashboard](https://stats.galaxyproject.eu/d/N9O36HWVk/mira-playground?orgId=1&refresh=5s&from=now-6h&to=now&timezone=browser&var-MQ=&viewPanel=panel-32)

This is important, because if the disks are misconfigured and the PARTLABEL is missing, the node will write to ram and might crash at some point, also the docker images would not be persistant if the `scratch` partition is not mounted