### PR TITLE
Add first AMD Genoa (1/17)

### DIFF
--- a/hosts
+++ b/hosts
@@ -6,3 +6,4 @@ c64m384g8-n3801.bi.privat
 [compute]
 tstimg.bi.privat
 c32m2048-n3681.bi.privat
+c192m1536-n3701.bi.privat


### PR DESCRIPTION
has the beautiful name
`c192m1536-n3701.bi.privat`
the others should follow soon..