### PR TITLE
Add group `interactive` for docker network restrictions

### DIFF
--- a/group_vars/interactive/firewall.yml
+++ b/group_vars/interactive/firewall.yml
@@ -1,0 +1,13 @@
+isolated_network_name: "interactive_network"
+isolated_subnet: "172.25.0.0/16"
+isolated_ip_range: "172.25.1.0/24"
+internal_networks:
+  - 10.4.68.0/24
+  - 10.5.67.0/24
+  - 10.5.68.0/24
+  - 132.230.68.0/24
+  - 132.230.223.0/24
+  - 132.230.224.0/24
+  - 10.5.153.0/24
+  - 132.230.153.0/25
+iptables_chain: "DOCKER_USER_ISOLATION"

--- a/hosts
+++ b/hosts
@@ -1,3 +1,10 @@
+# Nodes that should receive docker network restrictions should go here
+[interactive]
+c64m384g8-n3801.bi.privat
+
+[test]
+c64m384g8-n3801.bi.privat
+
 [divgpu4]
 # Nvidia L40S
 c128m512g4-n37104.bi.privat
@@ -5,7 +12,7 @@ c128m512g4-n37104.bi.privat
 # Nvidia L40S
 c128m512g4-n37103.bi.privat
 # Nvidia T4
-c64m384g8-n3801.bi.privat
+# c64m384g8-n3801.bi.privat
 [compute]
 tstimg.bi.privat
 # Intel Broadwell

--- a/tasks/restrict_docker.yml
+++ b/tasks/restrict_docker.yml
@@ -1,0 +1,46 @@
+---
+- name: Ensure Docker is installed and running
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
+
+- name: Create isolated Docker network
+  community.docker.docker_network:
+    name: "{{ isolated_network_name }}"
+    driver: bridge
+    ipam_config:
+      - subnet: "{{ isolated_subnet }}"
+        iprange: "{{ isolated_ip_range }}"
+    state: present
+
+- name: Insert jump to custom chain in DOCKER-USER
+  ansible.builtin.iptables:
+    chain_management: true
+    chain: DOCKER-USER
+    jump: "{{ iptables_chain }}"
+    action: insert
+    rule_num: 1
+    comment: "Jump to custom Docker user isolation rules"
+
+- name: Block access to internal networks from isolated network
+  ansible.builtin.iptables:
+    chain: "{{ iptables_chain }}"
+    source: "{{ isolated_subnet }}"
+    destination: "{{ item }}"
+    jump: DROP
+    comment: "Block access to internal network {{ item }}"
+  loop: "{{ internal_networks }}"
+
+- name: Allow established and related connections
+  ansible.builtin.iptables:
+    chain: "{{ iptables_chain }}"
+    ctstate: RELATED,ESTABLISHED
+    jump: ACCEPT
+    comment: "Allow established and related connections"
+
+- name: Return from custom chain (default action)
+  ansible.builtin.iptables:
+    chain: "{{ iptables_chain }}"
+    jump: RETURN
+    comment: "Return to DOCKER-USER chain"

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -88,6 +88,11 @@
         group: root
         mode: "0644"
       notify: Restart HTCondor
+  tasks:
+    - name: Restrict Docker network access for ITs
+      ansible.builtin.include_tasks:
+        file: tasks/restrict_docker.yml
+      when: "'interactive' in group_names"
 
   roles:
     - usegalaxy_eu.firewall


### PR DESCRIPTION
- Creates a new host group called `interactive`, hosts in this group get a docker network with nftable rules for preventing access to our private networks
- Move the T4 GPU node to the groups `test` and `interactive` so the network can be tested there using tiaas