### PR TITLE
Disable HTCondor for `c128m512g4-n37104.bi.privat`

### DIFF
--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -145,4 +145,5 @@
     - galaxyproject.cvmfs
     - cvmfs_cache_dir
 
-    - grycap.htcondor
+    - role: grycap.htcondor
+      when: inventory_hostname != "c128m512g4-n37104.bi.privat"


### PR DESCRIPTION
This host will be rebooted, disable HTCondor installation temporarily to provide a chance to ensure CVMFS works before the node starts accepting jobs.