### PR TITLE
Ensures cvac is mounted before installing cvmfs

### DIFF
--- a/roles/cvmfs_cache_dir/tasks/main.yml
+++ b/roles/cvmfs_cache_dir/tasks/main.yml
@@ -14,3 +14,7 @@
     owner: cvmfs
     group: cvmfs
     mode: "0770"
+
+- name: Reload cvmfs
+  ansible.builtin.command: cvmfs_config reload
+  become: true

--- a/roles/cvmfs_cache_dir/tasks/main.yml
+++ b/roles/cvmfs_cache_dir/tasks/main.yml
@@ -13,7 +13,3 @@
     owner: cvmfs
     group: cvmfs
     mode: "0770"
-
-- name: Reload cvmfs
-  ansible.builtin.command: cvmfs_config reload
-  become: true

--- a/roles/cvmfs_cache_dir/tasks/main.yml
+++ b/roles/cvmfs_cache_dir/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+# Mounts the nfs cvmfs alien cache with autofs (needed for when a vgcn as been rebooted)
+- name: Check directory exists silently
+  stat:
+    path: "{{ cvac.cvac08.path }}"
+  register: _cvac_path
+  changed_when: false
+  no_log: true
+
 - name: Ensure CVMFS disk cache directory exists
   ansible.builtin.file:
     path: "{{ cvmfs_cache_disk_base }}"

--- a/roles/cvmfs_cache_dir/tasks/main.yml
+++ b/roles/cvmfs_cache_dir/tasks/main.yml
@@ -3,7 +3,6 @@
 - name: Check directory exists silently
   stat:
     path: "{{ cvac.cvac08.path }}"
-  register: _cvac_path
   changed_when: false
   no_log: true
 

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -142,7 +142,7 @@
     - usegalaxy_eu.restrict_docker_net
 
     - usegalaxy-eu.autofs
-    - cvmfs_cache_dir
     - galaxyproject.cvmfs
+    - cvmfs_cache_dir
 
     - grycap.htcondor

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -142,7 +142,7 @@
     - usegalaxy_eu.restrict_docker_net
 
     - usegalaxy-eu.autofs
-    - galaxyproject.cvmfs
     - cvmfs_cache_dir
+    - galaxyproject.cvmfs
 
     - grycap.htcondor


### PR DESCRIPTION
My guess is that this will fix the fact that when a node is rebooted, cvmfs tries to mount a share that does not exists - thus the permission denied. 

I'm not sure if this is a bug that should be reported upstream