### PR TITLE
Mitigate DirtyClone

### DIFF
--- a/roles/dirtyclone_mitigation/tasks/main.yml
+++ b/roles/dirtyclone_mitigation/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Disable loading of DirtyClone-related modules
+  ansible.builtin.copy:
+    dest: /etc/modprobe.d/dirtyclone.conf
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+       install esp4 /bin/false
+       install esp6 /bin/false
+       install rxrpc /bin/false
+       blacklist esp4
+       blacklist esp6
+       blacklist rxrpc
+
+- name: Unload DirtyClone-related modules if currently loaded
+  ansible.builtin.command: "modprobe -r {{ item }}"
+  loop:
+    - esp4
+    - esp6
+    - rxrpc
+  register: dirtyclone_rmmod
+  changed_when: dirtyclone_rmmod.rc == 0
+  failed_when: false
+
+- name: Flush filesystem buffers to disk
+  ansible.builtin.command: sync
+  changed_when: false
+
+- name: Drop filesystem caches
+  ansible.posix.sysctl:
+    name: vm.drop_caches
+    value: "3"
+    state: present
+    sysctl_set: true

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -153,6 +153,8 @@
           notify: Restart HTCondor
           loop: "{{ htcondor_token_files.files }}"
   roles:
+    - dirtyclone_mitigation
+
     - usegalaxy_eu.firewall
     - usegalaxy_eu.restrict_docker_net
 


### PR DESCRIPTION
Even though DirtyClone has already been patched upstream, this should mitigate it until we are sure patches have reached all compute nodes. 

The mitigation is mostly a copy-paste of https://github.com/usegalaxy-eu/vgcn-infrastructure-playbook/pull/76.