### PR TITLE
Enable Rocky Linux security repository

### DIFF
--- a/roles/rocky_security_repository/meta/collection-requirements.yml
+++ b/roles/rocky_security_repository/meta/collection-requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: community.general
+    version: ">=8.2.0"

--- a/roles/rocky_security_repository/tasks/main.yml
+++ b/roles/rocky_security_repository/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: Ensure the latest Rocky Linux repository definitions are installed
+  ansible.builtin.dnf:
+    name: rocky-repos
+    state: latest
+
+- name: Enable the Rocky Linux security repository
+  # https://rockylinux.org/news/2026-05-14-introducing-security-repository
+  community.general.dnf_config_manager:
+    name: security
+    state: enabled

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -23,12 +23,9 @@
   pre_tasks:
     - name: Enable the Rocky Linux security repository
       # https://rockylinux.org/news/2026-05-14-introducing-security-repository
-      ansible.builtin.ini_file:
-        path: /etc/yum.repos.d/rocky-security.repo
-        section: security
-        option: enabled
-        value: "1"
-        mode: "0644"
+      community.general.dnf_config_manager:
+        name: security
+        state: enabled
 
     - name: Install proprietary Nvidia driver
       ansible.builtin.include_tasks:

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -21,6 +21,15 @@
         name: condor
         state: restarted
   pre_tasks:
+    - name: Enable the Rocky Linux security repository
+      # https://rockylinux.org/news/2026-05-14-introducing-security-repository
+      ansible.builtin.ini_file:
+        path: /etc/yum.repos.d/rocky-security.repo
+        section: security
+        option: enabled
+        value: "1"
+        mode: "0644"
+
     - name: Install proprietary Nvidia driver
       ansible.builtin.include_tasks:
         file: tasks/install-nvidia-proprietary.yml

--- a/vgcn-playbook.yml
+++ b/vgcn-playbook.yml
@@ -21,12 +21,6 @@
         name: condor
         state: restarted
   pre_tasks:
-    - name: Enable the Rocky Linux security repository
-      # https://rockylinux.org/news/2026-05-14-introducing-security-repository
-      community.general.dnf_config_manager:
-        name: security
-        state: enabled
-
     - name: Install proprietary Nvidia driver
       ansible.builtin.include_tasks:
         file: tasks/install-nvidia-proprietary.yml
@@ -159,6 +153,8 @@
           notify: Restart HTCondor
           loop: "{{ htcondor_token_files.files }}"
   roles:
+    - rocky_security_repository
+
     - usegalaxy_eu.firewall
     - usegalaxy_eu.restrict_docker_net
 


### PR DESCRIPTION
GLM-5.2 summary (that looks good enough to me):

> Rocky Linux has introduced an optional, opt-in Security Repository to ship urgent security fixes ahead of upstream Enterprise Linux when serious vulnerabilities (like CopyFail and Dirty Frag) become publicly exploitable before coordinated fixes arrive. Disabled by default to preserve Rocky's traditional upstream-aligned stability, the repository provides only temporary "bridge" patches that are explicitly versioned to be automatically superseded once upstream releases their own fixes—meaning they carry no errata records and don't appear in `dnf update --security`. The project acknowledges the trade-off: if upstream ultimately declines to fix an issue, the patched package will eventually be replaced by the next upstream release, leaving administrators with options like version-locking rather than an indefinitely maintained fork.

Read the official announcement https://rockylinux.org/news/2026-05-14-introducing-security-repository. Closes https://github.com/usegalaxy-eu/issues/issues/988.