### PR TITLE
Run interactive tools on v100 host

### DIFF
--- a/host_vars/c64m512g8-gpuv100.bi.privat/vars.yml
+++ b/host_vars/c64m512g8-gpuv100.bi.privat/vars.yml
@@ -1,0 +1,1 @@
+galaxy_group: interactive


### PR DESCRIPTION
Set `galaxy_group: interactive` for `c64m512g8-gpuv100.bi.privat` so that it runs interactive tools according to rules from https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2196.