### PR TITLE
Consider extra packages when removing old NVIDIA drivers for RHEL 10

### DIFF
--- a/tasks/install-nvidia-proprietary.yml
+++ b/tasks/install-nvidia-proprietary.yml
@@ -4,6 +4,7 @@
     cmd: nvidia-smi
   register: nvidia_smi
   failed_when: false
+  changed_when: false
 
 - name: Install NVIDIA driver if not correctly installed
   when: nvidia_smi.rc != 0

--- a/tasks/install-nvidia-proprietary.yml
+++ b/tasks/install-nvidia-proprietary.yml
@@ -17,7 +17,10 @@
     - name: Remove old driver RHEL 10
       ansible.builtin.dnf:
         state: absent
-        name: cuda-drivers
+        name:
+          - nvidia-driver-cuda-libs
+          - cuda-drivers
+          - kmod-nvidia-open-dkms
         allowerasing: true
       when: ansible_distribution_major_version == '10'
     - name: Create temporary build directory

--- a/tasks/install-nvidia-proprietary.yml
+++ b/tasks/install-nvidia-proprietary.yml
@@ -1,11 +1,11 @@
 ---
-- name: Check if Nvidia is correctly installed
+- name: Check if NVIDIA driver is correctly installed
   ansible.builtin.command:
     cmd: nvidia-smi
   register: nvidia_smi
   failed_when: false
 
-- name: Install if not
+- name: Install NVIDIA driver if not correctly installed
   when: nvidia_smi.rc != 0
   block:
     - name: Remove old driver RHEL 9
@@ -14,6 +14,7 @@
         name:
           - nvidia-driver
       when: ansible_distribution_major_version == '9'
+
     - name: Remove old driver RHEL 10
       ansible.builtin.dnf:
         state: absent
@@ -23,37 +24,45 @@
           - kmod-nvidia-open-dkms
         allowerasing: true
       when: ansible_distribution_major_version == '10'
+
     - name: Create temporary build directory
       ansible.builtin.tempfile:
         state: directory
         suffix: nvidia
       register: nvidia_tmp_dir
+
     - name: Download driver package
       ansible.builtin.get_url:
         url: "{{ nvidia_proprietary_url }}"
         dest: "/tmp/{{ nvidia_proprietary_url | split('/') | last }}"
+
     - name: Untar
       ansible.builtin.unarchive:
         src: "/tmp/{{ nvidia_proprietary_url | split('/') | last }}"
         dest: "/{{ nvidia_tmp_dir.path }}"
         remote_src: true
+
     - name: Make installation script executable
       ansible.builtin.file:
         path: "{{ nvidia_tmp_dir.path }}/NVIDIA-Linux-x86_64-{{ nvidia_proprietary_version }}.run"
         mode: "0755"
+
     - name: Run installation script
       ansible.builtin.command:
         cmd: "{{ nvidia_tmp_dir.path }}/NVIDIA-Linux-x86_64-{{ nvidia_proprietary_version }}.run -s"
+
     - name: Check if nvidia-smi is successful
       ansible.builtin.command:
         cmd: nvidia-smi
       register: nvidia_smi_after_install
       failed_when: false
+
     - name: Stop condor if not detected
       ansible.builtin.systemd_service:
         state: stopped
         name: condor
       when: nvidia_smi_after_install.rc != 0
+
     - name: Fail if nvidia-smi failed
       ansible.builtin.fail:
         msg: GPU not working!

--- a/tasks/install-nvidia-proprietary.yml
+++ b/tasks/install-nvidia-proprietary.yml
@@ -35,12 +35,12 @@
     - name: Download driver package
       ansible.builtin.get_url:
         url: "{{ nvidia_proprietary_url }}"
-        dest: "/tmp/{{ nvidia_proprietary_url | split('/') | last }}"
+        dest: "{{ nvidia_tmp_dir.path }}/{{ nvidia_proprietary_url | split('/') | last }}"
 
-    - name: Untar
+    - name: Extract driver package
       ansible.builtin.unarchive:
-        src: "/tmp/{{ nvidia_proprietary_url | split('/') | last }}"
-        dest: "/{{ nvidia_tmp_dir.path }}"
+        src: "{{ nvidia_tmp_dir.path }}/{{ nvidia_proprietary_url | split('/') | last }}"
+        dest: "{{ nvidia_tmp_dir.path }}"
         remote_src: true
 
     - name: Make installation script executable
@@ -68,3 +68,8 @@
       ansible.builtin.fail:
         msg: GPU not working!
       when: nvidia_smi_after_install.rc != 0
+  always:
+    - name: Remove temporary build directory
+      ansible.builtin.file:
+        path: "{{ nvidia_tmp_dir.path }}"
+        state: absent


### PR DESCRIPTION
It is not enough to remove `cuda-drivers`, remove `nvidia-driver-cuda-libs` and `kmod-nvidia-open-dkms` too.

Note: 44e70a7 is the only real change, the rest is cosmetic.